### PR TITLE
fix github project name in setup url

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 setup(name='django_openehr',
       version='0.0.3-01',
       description='openehr archetypes rendered as Django models',
-      url='https://github.com/openhealthcare/django_openehr',
+      url='https://github.com/openhealthcare/django-openehr',
       author='Open Health Care UK',
       license='MIT',
       packages=find_packages(),


### PR DESCRIPTION
s/django_openehr/django-openehr/

It's a tiny change, but without the link from PyPI to the repository is broken; please feel free to just squash this PR into whatever touches setup.py next...